### PR TITLE
Add capability for comparing ArrayType element equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Capability for comparing `ArrayType` element equality using the same user-specified parameters `precision` and `allow_nan_equality`. This applies to both `assert_df_equality` and `assert_column_equality`.
+
 ### Changed
 - `DataFramesNotEqualError` changed to `RowsNotEqualError` to reflect it being raised when testing for row equality.
 - The assertion functions `assert_df_equality` and `assert_column_equality` now have optional `precision` parameter to test for approximate equality.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,37 @@ Here's the pretty error message that's outputted:
 
 ![DataFramesNotEqualError](https://github.com/MrPowers/chispa/blob/main/images/dfs_not_approx_equal.png)
 
+## Comparing elements within ArrayType
+
+The core assertion methods `assert_df_equality` and `assert_column_equality` are capable of comparing elements within PySpark `ArrayType`. The `precision` and `allow_nan_equality` parameters are carried through when comparing array elements. It works for nested arrays too (if an `ArrayType` column holds further arrays as it's elements).
+
+Here are a couple of passing examples to illustrate this behaviour.
+
+```python
+def test_array_elements_are_equal_and_that_allow_nan_equality_carries_through():
+    """This test will pass."""
+    data1 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+    df1 = spark.createDataFrame(data1, ["n1", "n2"])
+
+    data2 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+    df2 = spark.createDataFrame(data2, ["n1", "n2"])
+
+    assert_df_equality(df1, df2, allow_nan_equality=True)
+
+
+def test_array_elements_with_mismatch_raises_error():
+    """This test will fail because the first array element in the first array
+    is different (more than the precision given).
+    """
+    data1 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.72], "karlov")]
+    df1 = spark.createDataFrame(data1, ["n1", "n2"])
+
+    data2 = [([1.9, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+    df2 = spark.createDataFrame(data2, ["n1", "n2"])
+
+    assert_df_equality(df1, df2, precision=0.1, allow_nan_equality=True)
+```
+
 ## Schema mismatch messages
 
 DataFrame equality messages perform schema comparisons before analyzing the actual content of the DataFrames.  DataFrames that don't have the same schemas should error out as fast as possible.

--- a/chispa/column_comparer.py
+++ b/chispa/column_comparer.py
@@ -5,7 +5,7 @@ from pyspark.sql.types import DataType
 
 from chispa.bcolors import blue
 from chispa.prettytable import PrettyTable
-from chispa.number_helpers import check_equal
+from chispa.number_helpers import check_equal_recursive
 
 
 class ColumnsNotEqualError(Exception):
@@ -71,4 +71,4 @@ def are_elements_equal(
     if (e1 is None and e2 is not None) or (e2 is None and e1 is not None):
         return False
 
-    return check_equal(e1, e2, precision, allow_nan_equality)
+    return check_equal_recursive(e1, e2, precision, allow_nan_equality)

--- a/chispa/number_helpers.py
+++ b/chispa/number_helpers.py
@@ -9,6 +9,27 @@ def isnan(x):
         return False
 
 
+def check_equal_recursive(
+    x, y,
+    precision: Optional[float] = None,
+    allow_nan_equality: bool = False,
+) -> bool:
+    """Return True if x and y are equal, including elements of arrays.
+
+    This function calls itself recursively to handle any level of array
+    nesting within the Spark Column.
+    """
+    if isinstance(x, list) & isinstance(y, list):
+        for e1, e2 in zip(x, y):
+            if not check_equal_recursive(e1, e2, precision, allow_nan_equality):
+                return False
+
+    elif not check_equal(x, y, precision, allow_nan_equality):
+        return False
+
+    return True
+
+
 def check_equal(
     x, y,
     precision: Optional[float] = None,

--- a/chispa/row_comparer.py
+++ b/chispa/row_comparer.py
@@ -4,7 +4,7 @@ from pyspark.sql import Row, DataFrame
 
 from chispa.bcolors import blue
 import chispa.six as six
-from chispa.number_helpers import check_equal
+from chispa.number_helpers import check_equal_recursive
 from chispa.prettytable import PrettyTable
 
 
@@ -71,6 +71,7 @@ def are_rows_equal(
 
     # Compare the values for each row. Order matters.
     for v1, v2 in zip(r1.asDict().values(), r2.asDict().values()):
-        if not check_equal(v1, v2, precision, allow_nan_equality):
+        if not check_equal_recursive(v1, v2, precision, allow_nan_equality):
             return False
+
     return True

--- a/tests/test_column_comparer.py
+++ b/tests/test_column_comparer.py
@@ -29,6 +29,31 @@ def describe_assert_column_equality():
         assert_column_equality(df, "num1", "num2", allow_nan_equality=True)
 
 
+    def it_equates_array_elements_correctly():
+        data = [([1.0, 7.2], [1.0, 7.2]), ([0.7, 5.6], [0.7, 5.6])]
+        df = spark.createDataFrame(data, ["array1", "array2"])
+        assert_column_equality(df, "array1", "array2")
+
+
+    def it_throws_when_there_is_array_element_mismatch():
+        data = [(['ice', 'cold'], ['ice', 'cold']), (['juice', 'box'], ['cardboard', 'box'])]
+        df = spark.createDataFrame(data, ["array1", "array2"])
+        with pytest.raises(ColumnsNotEqualError) as e_info:
+            assert_column_equality(df, "array1", "array2")
+
+
+    def it_equates_array_nan_elements_correctly_when_allow_nan_equality_is_True():
+        data = [([float('nan'), 7.2], [float('nan'), 7.2]), ([3.4, float('nan')], [3.4, float('nan')])]
+        df = spark.createDataFrame(data, ["array1", "array2"])
+        assert_column_equality(df, "array1", "array2", allow_nan_equality=True)
+
+
+    def it_equates_nested_array_elements_correctly():
+        data = [([[1.0], [7.2]], [[1.0], [7.2]]), ([[0.7]], [[0.7]])]
+        df = spark.createDataFrame(data, ["array1", "array2"])
+        assert_column_equality(df, "array1", "array2")
+
+
 def describe_assert_approx_column_equality():
     def it_works_with_no_mismatches():
         data = [(1.1, 1.1), (1.0004, 1.0005), (.4, .45), (None, None)]

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -182,6 +182,24 @@ def describe_assert_approx_column_equality():
         with pytest.raises(RowsNotEqualError) as e_info:
             assert_df_equality(df1, df2, precision=0.1)
 
+    def test_array_elements_are_equal_and_that_allow_nan_equality_carries_through():
+        data1 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+        df1 = spark.createDataFrame(data1, ["n1", "n2"])
+
+        data2 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+        df2 = spark.createDataFrame(data2, ["n1", "n2"])
+
+        assert_df_equality(df1, df2, allow_nan_equality=True)
+
+    def test_array_elements_with_mismatch_raises_error():
+        data1 = [([3.2, float('nan')], "jose"), ([float('nan'), 1.72], "karlov")]
+        df1 = spark.createDataFrame(data1, ["n1", "n2"])
+
+        data2 = [([1.9, float('nan')], "jose"), ([float('nan'), 1.7], "karlov")]
+        df2 = spark.createDataFrame(data2, ["n1", "n2"])
+        with pytest.raises(RowsNotEqualError) as e_info:
+            assert_df_equality(df1, df2, precision=0.1, allow_nan_equality=True)
+
 
 def describe_schema_mismatch_messages():
     def test_schema_mismatch_message():

--- a/tests/test_row_comparer.py
+++ b/tests/test_row_comparer.py
@@ -18,6 +18,23 @@ def describe_are_rows_equal_when_allowing_nan_equality():
         assert are_rows_equal(Row(n1=float('nan'), n2="jose"), Row(n1=float('nan'), n2="jose"), allow_nan_equality=True) == True
     def returns_False_when_comparing_nan_to_string():
         assert are_rows_equal(Row(n1=float('nan'), n2="jose"), Row(n1="hi", n2="jose"), allow_nan_equality=True) == False
+    def returns_True_when_comparing_nan_values_within_array():
+        assert are_rows_equal(
+            Row(n1=[3.2, float('nan')], n2="jose"),
+            Row(n1=[3.2, float('nan')], n2="jose"),
+            allow_nan_equality=True
+        ) == True
+    def returns_False_when_comparing_nan_values_within_array_if_allow_nan_equality_not_set():
+        assert are_rows_equal(
+            Row(n1=[3.2, float('nan')], n2="jose"),
+            Row(n1=[3.2, float('nan')], n2="jose"),
+        ) == False
+    def returns_True_when_comparing_nan_values_within_nested_array():
+        assert are_rows_equal(
+            Row(n1=[[float('nan')], [3.2, float('nan')], [1.2]], n2="jose"),
+            Row(n1=[[float('nan')], [3.2, float('nan')], [1.2]], n2="jose"),
+            allow_nan_equality=True
+        ) == True
 
 
 def describe_are_rows_equal_when_given_precision():


### PR DESCRIPTION
Added the `check_equal_recursive` function to apply check_equal to all
elements in arrays or nested arrays. Used this function in both
row_comparer and column_comparer so the functionality works for both
`assert_df_equality` and `assert_column_equality` and tests have been
written for each.

The README and Changlog have been updated to let users know about these
new capabilities.