### PR TITLE
Pass types through from schema rather than isinstance

### DIFF
--- a/chispa/number_helpers.py
+++ b/chispa/number_helpers.py
@@ -11,6 +11,7 @@ def isnan(x):
 
 def check_equal(
     x, y,
+    dtype_name: str,
     precision: Optional[float] = None,
     allow_nan_equality: bool = False,
 ) -> bool:
@@ -18,14 +19,17 @@ def check_equal(
 
     Parameters
     ----------
+    dtype : pyspark DataType
+        The type of the values from the schema.
     precision : float, optional
         Absolute tolerance when checking for equality.
     allow_nan_equality: bool, defaults to False
         When True, treats two NaN values as equal.
 
     """
-    both_floats = (isinstance(x, float) & isinstance(y, float))
-    if (precision is not None) & both_floats:
+    is_float_type = (dtype_name in ['float', 'double', 'decimal'])
+
+    if all([i is not None for i in [x, y, precision]]) & is_float_type:
         both_equal = abs(x - y) < precision
     else:
         both_equal = (x == y)

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -116,8 +116,9 @@ def describe_assert_df_equality():
             assert_df_equality(df1, df2, allow_nan_equality=False)
 
 
-def describe_assert_approx_df_equality():
+def describe_assert_df_equality_with_precision():
     def it_throws_with_content_mismatch():
+        """The values in the last row are different."""
         data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (1.0, None)]
         df1 = spark.createDataFrame(data1, ["num", "expected_name"])
         data2 = [(1.0, "jose"), (1.05, "li"), (1.0, "laura"), (None, "hi")]
@@ -127,6 +128,7 @@ def describe_assert_approx_df_equality():
 
 
     def it_throws_with_with_length_mismatch():
+        """df1 is two rows longer than df2 so it should throw error."""
         data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
         df1 = spark.createDataFrame(data1, ["num", "expected_name"])
         data2 = [(1.0, "jose"), (1.05, "li")]
@@ -136,8 +138,17 @@ def describe_assert_approx_df_equality():
 
 
     def it_does_not_throw_with_no_mismatch():
+        """Both dfs should be equal with given precision."""
         data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
         df1 = spark.createDataFrame(data1, ["num", "expected_name"])
         data2 = [(1.0, "jose"), (1.05, "li"), (1.2, "laura"), (None, None)]
         df2 = spark.createDataFrame(data2, ["num", "expected_name"])
         assert_df_equality(df1, df2, precision=0.1)
+
+
+if __name__ == "__main__":
+    data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
+    df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+    data2 = [(1.0, "jose"), (1.05, "li"), (1.2, "laura"), (None, None)]
+    df2 = spark.createDataFrame(data2, ["num", "expected_name"])
+    assert_df_equality(df1, df2, precision=0.1)

--- a/tests/test_row_comparer.py
+++ b/tests/test_row_comparer.py
@@ -1,32 +1,87 @@
 from chispa.row_comparer import are_rows_equal
 from pyspark.sql import Row
+from pyspark.sql.types import *
+import pytest
+
+
+@pytest.fixture(params=['float', 'double', 'decimal'])
+def float_str_dtypes(request):
+    return [request.param, 'string']
 
 
 def describe_are_rows_equal():
     def returns_False_when_string_values_are_not_equal():
-        assert are_rows_equal(Row(n1="bob", n2="jose"), Row(n1="li", n2="li")) == False
+        assert not are_rows_equal(
+            Row(n1="bob", n2="jose"),
+            Row(n1="li", n2="li"),
+            dtypes=['string', 'string'],
+        )
     def returns_True_when_string_values_are_equal():
-        assert are_rows_equal(Row(n1="luisa", n2="laura"), Row(n1="luisa", n2="laura")) == True
+        assert are_rows_equal(
+            Row(n1="luisa", n2="laura"),
+            Row(n1="luisa", n2="laura"),
+            dtypes=['string', 'string'],
+        )
     def returns_True_when_both_rows_are_None():
-        assert are_rows_equal(Row(n1=None, n2=None), Row(n1=None, n2=None)) == True
+        assert are_rows_equal(
+            Row(n1=None, n2=None),
+            Row(n1=None, n2=None),
+            dtypes=['string', 'string'],
+        )
 
 
 def describe_are_rows_equal_when_allowing_nan_equality():
     def returns_False_when_no_NaN_values_to_compare_and_other_values_are_not_equal():
-        assert are_rows_equal(Row(n1="bob", n2="jose"), Row(n1="li", n2="li"), allow_nan_equality=True) == False
-    def returns_True_when_either_the_values_are_equal_or_both_nan():
-        assert are_rows_equal(Row(n1=float('nan'), n2="jose"), Row(n1=float('nan'), n2="jose"), allow_nan_equality=True) == True
-    def returns_False_when_comparing_nan_to_string():
-        assert are_rows_equal(Row(n1=float('nan'), n2="jose"), Row(n1="hi", n2="jose"), allow_nan_equality=True) == False
+        assert not are_rows_equal(
+            Row(n1="bob", n2="jose"),
+            Row(n1="li", n2="li"),
+            dtypes=['string', 'string'],
+            allow_nan_equality=True,
+        )
+    def returns_True_when_either_the_values_are_equal_or_both_nan(float_str_dtypes):
+        assert are_rows_equal(
+            Row(n1=float('nan'), n2="jose"),
+            Row(n1=float('nan'), n2="jose"),
+            dtypes=float_str_dtypes,
+            allow_nan_equality=True,
+        )
+    # NOTE: This test might not be needed as the schema would have failed before.
+    def returns_False_when_comparing_nan_to_string(float_str_dtypes):
+        assert not are_rows_equal(
+            Row(n1=float('nan'), n2="jose"),
+            Row(n1="hi", n2="jose"),
+            dtypes=float_str_dtypes,
+            allow_nan_equality=True,
+        )
 
 
 def describe_are_rows_equal_when_given_precision():
-    def returns_True_when_float_value_difference_is_less_than_precision():
-        assert are_rows_equal(Row(num = 1.1, first_name = "li"), Row(num = 1.05, first_name = "li"), precision=0.1) == True
-    def returns_True_when_float_values_are_exactly_equal():
-        assert are_rows_equal(Row(num = 5.0, first_name = "laura"), Row(num = 5.0, first_name = "laura"), precision=0.1) == True
-    def returns_False_when_float_value_difference_is_more_than_precision():
-        assert are_rows_equal(Row(num = 5.0, first_name = "laura"), Row(num = 5.9, first_name = "laura"), precision=0.1) == False
-    def returns_True_when_all_values_are_Nones():
-        assert are_rows_equal(Row(num = None, first_name = None), Row(num = None, first_name = None), precision=0.1) == True
+    def returns_True_when_float_value_difference_is_less_than_precision(float_str_dtypes):
+        assert are_rows_equal(
+            Row(num = 1.1, first_name = "li"),
+            Row(num = 1.05, first_name = "li"),
+            dtypes=float_str_dtypes,
+            precision=0.1,
+        )
+    def returns_True_when_float_values_are_exactly_equal(float_str_dtypes):
+        assert are_rows_equal(
+            Row(num = 5.0, first_name = "laura"),
+            Row(num = 5.0, first_name = "laura"),
+            dtypes=float_str_dtypes,
+            precision=0.1,
+        )
+    def returns_False_when_float_value_difference_is_more_than_precision(float_str_dtypes):
+        assert not are_rows_equal(
+            Row(num = 5.0, first_name = "laura"),
+            Row(num = 5.9, first_name = "laura"),
+            dtypes=float_str_dtypes,
+            precision=0.1,
+        )
+    def returns_True_when_all_values_are_Nones(float_str_dtypes):
+        assert are_rows_equal(
+            Row(num = None, first_name = None),
+            Row(num = None, first_name = None),
+            dtypes=float_str_dtypes,
+            precision=0.1,
+        )
 


### PR DESCRIPTION
This occurs in check_equal when deciding if something is float or not.